### PR TITLE
Add details sidebar 

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "@patternfly/react-styles": "5.0.0-alpha.8",
     "@patternfly/react-table": "5.0.0-alpha.85",
     "@patternfly/react-tokens": "5.0.0-alpha.9",
+    "date-fns": "2.30.0",
     "react": "18.2.0",
     "react-dom": "18.2.0"
   }

--- a/src/app.jsx
+++ b/src/app.jsx
@@ -29,6 +29,7 @@ import {
     MenuToggle, MenuToggleAction,
     Page, PageBreadcrumb, PageSection,
     SearchInput, Select, SelectList, SelectOption,
+    Sidebar, SidebarPanel, SidebarContent,
     Text, TextContent, TextVariants,
 } from "@patternfly/react-core";
 import { ArrowLeftIcon, ArrowRightIcon, FileIcon, FolderIcon, GripVerticalIcon, ListIcon } from "@patternfly/react-icons";
@@ -112,17 +113,17 @@ export const Application = () => {
         <Page>
             <NavigatorBreadcrumbs path={path} setPath={setPath} pathIndex={pathIndex} setPathIndex={setPathIndex} />
             <PageSection>
-                <Flex>
-                    <FlexItem flex={{ lg: 'flex_3' }}>
+                <Sidebar isPanelRight hasGutter>
+                    <SidebarPanel className="sidebar-panel">
+                        <SidebarPanelDetails selected={files.find(file => file.name === selected) || ({ name: path[path.length - 1], items_cnt: { all: files.length, hidden: files.length - visibleFiles.length } })} />
+                    </SidebarPanel>
+                    <SidebarContent>
                         <Card>
                             <NavigatorCardHeader currentFilter={currentFilter} onFilterChange={onFilterChange} isGrid={isGrid} setIsGrid={setIsGrid} sortBy={sortBy} setSortBy={setSortBy} />
                             <NavigatorCardBody currentFilter={currentFilter} files={visibleFiles} setPath={setPath} path={path} pathIndex={pathIndex} setPathIndex={setPathIndex} isGrid={isGrid} sortBy={sortBy} setSelected={setSelected} />
                         </Card>
-                    </FlexItem>
-                    <FlexItem flex={{ lg: 'flex_1' }}>
-                        <Sidebar selected={files.find(file => file.name === selected) || ({ name: path[path.length - 1], items_cnt: { all: files.length, hidden: files.length - visibleFiles.length } })} />
-                    </FlexItem>
-                </Flex>
+                    </SidebarContent>
+                </Sidebar>
             </PageSection>
         </Page>
     );
@@ -266,9 +267,9 @@ const NavigatorCardBody = ({ currentFilter, files, isGrid, setPath, path, pathIn
     }
 };
 
-const Sidebar = ({ selected }) => {
+const SidebarPanelDetails = ({ selected }) => {
     return (
-        <Card id="sidebar-card">
+        <Card className="sidebar-card">
             <CardHeader>
                 <CardTitle component="h2" id="sidebar-card-header">
                     <TextContent>

--- a/src/app.scss
+++ b/src/app.scss
@@ -26,3 +26,8 @@
 .check-icon {
     color: var(--pf-global--primary-color--100);
 }
+
+#sidebar-card {
+    background: inherit;
+    box-shadow: none;
+}

--- a/src/app.scss
+++ b/src/app.scss
@@ -27,7 +27,12 @@
     color: var(--pf-global--primary-color--100);
 }
 
-#sidebar-card {
+.sidebar-card {
     background: inherit;
     box-shadow: none;
+}
+
+.sidebar-panel {
+    background-color: var(--pf-c-page__main-section--BackgroundColor);
+    top: 3rem;
 }

--- a/test/check-application
+++ b/test/check-application
@@ -16,6 +16,10 @@ import testlib
 # They must not permanently change any file or configuration on the system in a way that influences other tests.
 @testlib.nondestructive
 class TestNavigator(testlib.MachineCase):
+    @classmethod
+    def setUpClass(cls):
+        # Run browser in UTC as the displayed time is in the browser's timezone
+        os.environ['TZ'] = 'UTC'
 
     # FIXME: Move to testlib.py
     def select_PF5(self, b, selector_button: str, selector: str, value):
@@ -31,20 +35,49 @@ class TestNavigator(testlib.MachineCase):
 
         self.login_and_go("/navigator")
         # expected heading
-        b.wait_text(".pf-c-card__title", "Directories & files")
+        b.wait_text("#navigator-card-header", "Directories & files")
+        b.wait_in_text("#sidebar-card-header", "admin")
 
         # new files are auto-detected
-        m.execute("touch /home/admin/newfile")
+        m.execute("touch --date @1641038400 /home/admin/newfile")
         b.wait_visible("[data-item='newfile']")
 
         # new directories are auto-detected
-        m.execute("mkdir /home/admin/newdir")
+        m.execute("mkdir /home/admin/newdir; touch --date @1641038400 /home/admin/newfile /home/admin/newdir")
         b.wait_visible("[data-item='newdir']")
 
         # hidden files are not displayed
         m.execute("touch /home/admin/.hiddenfile /home/admin/not-hidden")
         b.wait_visible("[data-item='not-hidden']")
         b.wait_not_present("[data-item='.hiddenfile']")
+
+        # file sidebar information
+        b.click("button:contains('newfile')")
+        b.wait_text("#sidebar-card-header", "newfile")
+        b.wait_text("#description-list-owner dd", "root")
+        b.wait_text("#description-list-group dd", "root")
+        b.wait_text("#description-list-size dd", "0 B")
+        b.wait_text("#description-list-last-modified dd", "Jan 1, 2022, 12:00 PM")
+
+        # saving a file updates sidebar info
+        # FIXME: Size does not update
+        m.execute("head -c 7 /dev/zero > /home/admin/newfile")
+        b.wait_text("#description-list-size dd", "7 B")
+        b.wait_not_in_text("#description-list-last-modified ", "Jan 1, 2022, 12:00 PM")
+        m.execute("touch --date @1641038400 /home/admin/newfile")
+        b.wait_in_text("#description-list-last-modified ", "Jan 1, 2022, 12:00 PM")
+
+        # clicking empty space resets sidebar
+        b.click("#folder-view")
+        b.wait_in_text("#sidebar-card-header", "admin")
+
+        # folder information doesn't contain size
+        b.click("button:contains('newdir')")
+        b.wait_text("#sidebar-card-header", "newdir")
+        b.wait_text("#description-list-owner dd", "root")
+        b.wait_text("#description-list-group dd", "root")
+        b.wait_not_present("#description-list-size")
+        b.wait_text("#description-list-last-modified dd", "Jan 1, 2022, 12:00 PM")
 
         # filtering works
         self.browser.wait_js_cond("ph_count('#folder-view > button') > 1")
@@ -63,6 +96,9 @@ class TestNavigator(testlib.MachineCase):
         b.wait_not_present("[data-item='newdir']")
         b.wait_not_present("[data-item='newfile']")
 
+        # sidebar is reset when files are removed
+        b.wait_in_text("#sidebar-card-header", "admin")
+
     def testNavigation(self):
         b = self.browser
         m = self.machine
@@ -78,10 +114,17 @@ class TestNavigator(testlib.MachineCase):
         b.wait_not_present(".breadcrumb-button:nth-of-type(3)")
         b.wait_visible("[data-item='admin']")
 
+        # show folder info in sidebar
+        b.click("button:contains('admin')")
+        b.wait_in_text("#sidebar-card-header", "admin")
+
         # double-clicking on a directory should take us into it
         b.mouse("[data-item='admin']", "dblclick")
         b.wait_not_present("[data-item='admin']")
         b.wait_text(".breadcrumb-button:nth-of-type(3)", "admin")
+
+        # navigating into a directory resets the sidebar
+        b.wait_in_text("#sidebar-card-header", "admin")
 
     def testSorting(self):
         b = self.browser
@@ -90,7 +133,7 @@ class TestNavigator(testlib.MachineCase):
         self.login_and_go("/navigator")
 
         # Expected heading
-        b.wait_text(".pf-c-card__title", "Directories & files")
+        b.wait_text("#navigator-card-header", "Directories & files")
 
         # Create test files and folders
         m.execute("touch -d '3 hours ago' /home/admin/aaa")

--- a/test/check-application
+++ b/test/check-application
@@ -36,7 +36,9 @@ class TestNavigator(testlib.MachineCase):
         self.login_and_go("/navigator")
         # expected heading
         b.wait_text("#navigator-card-header", "Directories & files")
-        b.wait_in_text("#sidebar-card-header", "admin")
+        files_cnt = m.execute("ls -A /home/admin | wc -l").strip()
+        hidden_files_cnt = m.execute('ls -A /home/admin | grep "^\." | wc -l').strip()
+        b.wait_text("#sidebar-card-header", f"admin{files_cnt} items ({hidden_files_cnt} hidden)")
 
         # new files are auto-detected
         m.execute("touch --date @1641038400 /home/admin/newfile")
@@ -95,6 +97,11 @@ class TestNavigator(testlib.MachineCase):
         m.execute("rm /home/admin/newfile")
         b.wait_not_present("[data-item='newdir']")
         b.wait_not_present("[data-item='newfile']")
+
+        # current directory sidebar item count is updated
+        files_cnt = m.execute("ls -A /home/admin | wc -l").strip()
+        hidden_files_cnt = m.execute('ls -A /home/admin | grep "^\." | wc -l').strip()
+        b.wait_text("#sidebar-card-header", f"admin{files_cnt} items ({hidden_files_cnt} hidden)")
 
         # sidebar is reset when files are removed
         b.wait_in_text("#sidebar-card-header", "admin")


### PR DESCRIPTION
Closes #28.

To do:
* [x] Run fslist again on create/change event to fetch file information
* [x] Update sidebar info when file is updated/removed
* [ ] Make sidebar length match navigator card (can be fone in followup)
* [x] Unselect when clicking on empty space
* [x] Show file/folder info
* [ ] Show permissions (can be done in followup)
* [ ] Show more info for current directory (can be done in followup)
* [x] Write tests