### PR TITLE
fmf: Plumb through $TEST_* variables for unexpected messages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -184,10 +184,10 @@ print-vm:
 # without actually running them
 prepare-check: $(NODE_MODULES_TEST) $(VM_IMAGE) test/common
 
-# run the browser integration tests; skip check for SELinux denials
+# run the browser integration tests
 # this will run all tests/check-* and format them as TAP
 check: prepare-check
-	TEST_AUDIT_NO_SELINUX=1 test/common/run-tests ${RUN_TESTS_OPTIONS}
+	test/common/run-tests ${RUN_TESTS_OPTIONS}
 
 # checkout Cockpit's bots for standard test VM images and API to launch them
 bots: test/common

--- a/plans/all.fmf
+++ b/plans/all.fmf
@@ -4,3 +4,7 @@ discover:
     how: fmf
 execute:
     how: tmt
+
+# Let's handle them upstream only, don't break Fedora/RHEL reverse dependency gating
+environment:
+    TEST_AUDIT_NO_SELINUX: 1

--- a/test/browser/browser.sh
+++ b/test/browser/browser.sh
@@ -1,9 +1,11 @@
 #!/bin/sh
 set -eux
 
+export TEST_BROWSER=${TEST_BROWSER:-firefox}
+
 TESTS="$(realpath $(dirname "$0"))"
-SOURCE="$(realpath $TESTS/../..)"
-LOGS="$(pwd)/logs"
+export SOURCE="$(realpath $TESTS/../..)"
+export LOGS="$(pwd)/logs"
 mkdir -p "$LOGS"
 chmod a+w "$LOGS"
 
@@ -47,7 +49,10 @@ echo core > /proc/sys/kernel/core_pattern
 systemctl enable --now cockpit.socket
 
 # Run tests as unprivileged user
-su - -c "env TEST_BROWSER=firefox SOURCE=$SOURCE LOGS=$LOGS $TESTS/run-test.sh" runtest
+# once we drop support for RHEL 8, use this:
+# runuser -u runtest --whitelist-environment=TEST_BROWSER,TEST_ALLOW_JOURNAL_MESSAGES,TEST_AUDIT_NO_SELINUX,SOURCE,LOGS $TESTS/run-test.sh
+runuser -u runtest --preserve-environment env USER=runtest HOME=$(getent passwd runtest | cut -f6 -d:) $TESTS/run-test.sh
+
 
 RC=$(cat $LOGS/exitcode)
 exit ${RC:-1}

--- a/test/browser/run-test.sh
+++ b/test/browser/run-test.sh
@@ -22,13 +22,16 @@ mv .git dot-git
 
 . /etc/os-release
 export TEST_OS="${ID}-${VERSION_ID/./-}"
-export TEST_AUDIT_NO_SELINUX=1
 
 if [ "${TEST_OS#centos-}" != "$TEST_OS" ]; then
     TEST_OS="${TEST_OS}-stream"
 fi
 
 EXCLUDES=""
+
+# make it easy to check in logs
+echo "TEST_ALLOW_JOURNAL_MESSAGES: ${TEST_ALLOW_JOURNAL_MESSAGES:-}"
+echo "TEST_AUDIT_NO_SELINUX: ${TEST_AUDIT_NO_SELINUX:-}"
 
 RC=0
 test/common/run-tests --nondestructive --machine 127.0.0.1:22 --browser 127.0.0.1:9090 $EXCLUDES || RC=$?


### PR DESCRIPTION
This will allow us to control the value from test plans, in particular for disabling at least some unexpected message checks for reverse dependency testing. We don't want to disable unexpected messages in general for fmf, as we are looking for exactly these in e.g. selinux-policy reverse dependency tests.

Move from `su` to `runtest`, as with the former it's impossible to plumb through variables with non-trivial characters, as they cannot be quoted.

Taken from https://github.com/cockpit-project/cockpit-podman/commit/c38692fa4ce66